### PR TITLE
Add env var to point the theme root somewhere else.

### DIFF
--- a/lib/staytus/config.rb
+++ b/lib/staytus/config.rb
@@ -9,7 +9,7 @@ module Staytus
       end
 
       def theme_root
-        Rails.root.join('content', 'themes', self.theme_name)
+        ENV['STAYTUS_THEME_ROOT'] || Rails.root.join('content', 'themes', self.theme_name)
       end
 
       def version


### PR DESCRIPTION
I am currently integrating Staytus into NixOS. This change will allow me to pass a theme from another package. The problem is that packages in NixOS are read-only, which means I cannot copy a theme into the staytus package once it is already there.